### PR TITLE
Faster Qulacs expval

### DIFF
--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -98,8 +98,17 @@ class QulacsDevice(QubitDevice):
         "PhaseShift": phase_shift,
     }
 
+    _observable_map = {
+        "PauliX": "X",
+        "PauliY": "Y",
+        "PauliZ": "Z",
+        "Identity": "I",
+        "Hadamard": None,
+        "Hermitian": None,
+    }
+
     operations = _operation_map.keys()
-    observables = {"PauliX", "PauliY", "PauliZ", "Identity", "Hadamard", "Hermitian"}
+    observables = _observable_map.keys()
 
     # Add inverse gates to _operation_map
     _operation_map.update({k + ".inv": v for k, v in _operation_map.items()})
@@ -296,21 +305,12 @@ class QulacsDevice(QubitDevice):
         return prob
 
     def expval(self, observable):
-        observable_map = {
-            "PauliX": "X",
-            "PauliY": "Y",
-            "PauliZ": "Z",
-            "Identity": "I",
-            "Hadamard": None,
-            "Hermitian": None,
-        }
-
         if self.analytic:
             qulacs_observable = Observable(self.num_wires)
             if isinstance(observable.name, list):
-                observables = [observable_map[obs] for obs in observable.name]
+                observables = [self._observable_map[obs] for obs in observable.name]
             else:
-                observables = [observable_map[observable.name]]
+                observables = [self._observable_map[observable.name]]
 
             if None not in observables:
                 applied_wires = self.map_wires(observable.wires).tolist()

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -303,7 +303,7 @@ class QulacsDevice(QubitDevice):
             "PauliZ": "Z",
             "Identity": "I",
             "Hadamard": None,
-            "Hermitian": None
+            "Hermitian": None,
         }
 
         if self.analytic:
@@ -315,17 +315,16 @@ class QulacsDevice(QubitDevice):
 
             if None not in observables:
                 opp = " ".join(
-                    [f"{obs} {observable.wires.labels[i]}"
-                     for i, obs in enumerate(observables)]
+                    [f"{obs} {observable.wires.labels[i]}" for i, obs in enumerate(observables)]
                 )
 
-                qulacs_observable.add_operator(1., opp)
+                qulacs_observable.add_operator(1.0, opp)
                 return qulacs_observable.get_expectation_value(self._pre_rotated_state)
-            else:
-                # exact expectation value
-                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
-                prob = self.probability(wires=observable.wires)
-                return self._dot(eigvals, prob)
+
+            # exact expectation value
+            eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
+            prob = self.probability(wires=observable.wires)
+            return self._dot(eigvals, prob)
 
         # estimate the ev
         return np.mean(self.sample(observable))

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -120,13 +120,13 @@ class QulacsDevice(QubitDevice):
 
         self._circuit = QuantumCircuit(self.num_wires)
 
-        self._pre_rotated_state = self._state
+        self._pre_rotated_state = self._state.copy()
 
     def apply(self, operations, **kwargs):
         rotations = kwargs.get("rotations", [])
 
         self.apply_operations(operations)
-        self._pre_rotated_state = self._state
+        self._pre_rotated_state = self._state.copy()
 
         # Rotating the state for measurement in the computational basis
         if rotations:
@@ -315,12 +315,12 @@ class QulacsDevice(QubitDevice):
 
             if None not in observables:
                 opp = " ".join(
-                    [f"{obs} {self.num_wires - observable.wires.labels[i]-1}"
+                    [f"{obs} {observable.wires.labels[i]}"
                      for i, obs in enumerate(observables)]
                 )
 
                 qulacs_observable.add_operator(1., opp)
-                return qulacs_observable.get_expectation_value(self._state)
+                return qulacs_observable.get_expectation_value(self._pre_rotated_state)
             else:
                 # exact expectation value
                 eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
@@ -333,9 +333,9 @@ class QulacsDevice(QubitDevice):
     @property
     def state(self):
         # returns the state after all operations are applied
-        return _reverse_state(self._pre_rotated_state.get_vector())
+        return _reverse_state(self._state.get_vector())
 
     def reset(self):
         self._state.set_zero_state()
-        self._pre_rotated_state = self._state
+        self._pre_rotated_state = self._state.copy()
         self._circuit = QuantumCircuit(self.num_wires)

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -296,7 +296,6 @@ class QulacsDevice(QubitDevice):
         return prob
 
     def expval(self, observable):
-
         observable_map = {
             "PauliX": "X",
             "PauliY": "Y",
@@ -314,9 +313,8 @@ class QulacsDevice(QubitDevice):
                 observables = [observable_map[observable.name]]
 
             if None not in observables:
-                opp = " ".join(
-                    [f"{obs} {observable.wires.labels[i]}" for i, obs in enumerate(observables)]
-                )
+                applied_wires = self.map_wires(observable.wires).tolist()
+                opp = " ".join([f"{obs} {applied_wires[i]}" for i, obs in enumerate(observables)])
 
                 qulacs_observable.add_operator(1.0, opp)
                 return qulacs_observable.get_expectation_value(self._pre_rotated_state)


### PR DESCRIPTION
Use native expectation value calculations.

Seemingly works now. There were issues with rotations, so I just used `self._pre_rotated_states` instead, and also made it into a copy of `self._state`, rather than a reference, which was the case before.

Two questions left:

1. Do we need rotations at all now, and if not, why should the `QulacsDevice.state` property return the post-rotated states (otherwise the tests seem to fail)? It was actually using the `self._pre_rotated_states` before, but since that was just a reference to `self._state`, it was actually using the post-rotated states all along.

2. Not sure what to do about the Hadamard and Hermitian observables. Currently it uses the old expval calculations in those specific cases.
