### PR TITLE
Adjusts the matrix of CRZ

### DIFF
--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -37,11 +37,15 @@ except ImportError:
     GPU_SUPPORTED = False
 
 phase_shift = lambda phi: np.array([[1, 0], [0, cmath.exp(1j * phi)]])
+
+# Multi-qubit gates are affected by the convention used by Qulacs
+# For a controlled operationd the first qubit is the target and the second
+# qubit is the control
 crz = lambda theta: np.array(
     [
         [1, 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 0, cmath.exp(-1j * theta / 2), 0],
+        [0,  cmath.exp(-1j * theta / 2), 0, 0],
+        [0, 0, 1, 0],
         [0, 0, 0, cmath.exp(1j * theta / 2)],
     ]
 )

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -38,9 +38,9 @@ except ImportError:
 
 phase_shift = lambda phi: np.array([[1, 0], [0, cmath.exp(1j * phi)]])
 
-# Multi-qubit gates are affected by the convention used by Qulacs
-# For a controlled operationd the first qubit is the target and the second
-# qubit is the control
+# Multi-qubit gates are represented in the convention of Qulacs
+# E.g., for a controlled operation the first qubit is the target and the second
+# qubit is the control with consecutive wires
 crz = lambda theta: np.array(
     [
         [1, 0, 0, 0],

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -44,7 +44,7 @@ phase_shift = lambda phi: np.array([[1, 0], [0, cmath.exp(1j * phi)]])
 crz = lambda theta: np.array(
     [
         [1, 0, 0, 0],
-        [0,  cmath.exp(-1j * theta / 2), 0, 0],
+        [0, cmath.exp(-1j * theta / 2), 0, 0],
         [0, 0, 1, 0],
         [0, 0, 0, cmath.exp(1j * theta / 2)],
     ]

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -47,6 +47,8 @@ phase_shift = lambda phi: np.array([[1, 0], [0, np.exp(1j * phi)]])
 rx = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * X
 ry = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Y
 rz = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Z
+
+# CRZ in the PennyLane convention
 crz = lambda theta: np.array(
     [
         [1, 0, 0, 0],
@@ -143,8 +145,8 @@ class TestStateApply:
         dev.apply([op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(state) ** 2
+        res = dev.state
+        expected = state
         assert np.allclose(res, expected, tol)
 
     def test_invalid_qubit_state_vector(self):
@@ -166,8 +168,8 @@ class TestStateApply:
         dev.apply([qml.QubitStateVector(state, wires=[0]), op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev.state
+        expected = mat @ state
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
@@ -181,8 +183,8 @@ class TestStateApply:
         dev.apply([qml.QubitStateVector(state, wires=[0]), op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev.state
+        expected = func(theta) @ state
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("op, mat", two_qubit)
@@ -194,8 +196,8 @@ class TestStateApply:
         dev.apply([qml.QubitStateVector(state, wires=[0, 1]), op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev.state
+        expected = mat @ state
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("mat", [U, U2])
@@ -210,8 +212,8 @@ class TestStateApply:
         dev.apply([qml.QubitStateVector(state, wires=list(range(N))), op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev.state
+        expected = mat @ state
         assert np.allclose(res, expected, tol)
 
     def test_invalid_qubit_state_unitary(self):
@@ -232,8 +234,8 @@ class TestStateApply:
         dev.apply([qml.QubitStateVector(state, wires=[0, 1, 2]), op])
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev.state
+        expected = mat @ state
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
@@ -248,8 +250,8 @@ class TestStateApply:
 
         dev._obs_queue = []
 
-        res = np.abs(dev.state) ** 2
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev.state
+        expected = func(theta) @ state
         assert np.allclose(res, expected, tol)
 
     def test_apply_errors_qubit_state_vector(self):


### PR DESCRIPTION
**Context**

The new test in the [device test suite failed](https://github.com/PennyLaneAI/plugin-test-matrix/runs/1758930370?check_suite_focus=true).

It seems to have come down to the `CRZ` operation that has a custom definition in the plugin.

**Changes**
* Adjusts the matrix of `CRZ` to use the Qulacs convention (see [Qiskit ](https://qiskit.org/documentation/stubs/qiskit.circuit.library.CRZGate.html#qiskit.circuit.library.CRZGate)that uses the same convention for the matrix and description)
* Changes tests that apply an operation such that state vectors are compared instead of probabilities. This is done because different state vectors can produce the same basis state probabilities (this was the case for `CRZ`).