### PR TITLE
In requirements, Qulacs is capitalized

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pennylane>=0.11
-qulacs>=0.1.10.1
+Qulacs>=0.1.10.1
 numpy~=1.16


### PR DESCRIPTION
Upon installing the plugin from source, `Qulacs` wasn't installed as a dependency because the package name is supposed to be capitalized.  It wasn't capitalized in `requirements.txt`.