### PR TITLE
Fix wire ordering for `QubitStateVector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Bug fixes
 
+Fixes an issue when the wrong results are returned when passing non-consecutive wires to `QubitStateVector`.
+[(#25)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/25)
+
 ### Breaking changes
 
 ### Documentation
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Theodor Isacsson
 
 # Release 0.15.0
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -172,9 +172,28 @@ class QulacsDevice(QubitDevice):
             else:
                 self._apply_gate(op)
 
+    def _transpose_state_for_wires(self, state_vector, wires):
+        """Transpose state vector if the wires are in non-consecutive order
+
+        Note, this also reverses the state, same as `_reverse_state()`.
+
+        Args:
+            state_vector (iterable[complex]): vector containing the amplitudes
+            wires (Wires): wires that get initialized in the state
+
+        Returns:
+            array[complex]: transposed array
+
+        """
+        wire_order = np.array(wires).argsort().argsort()[::-1]
+
+        N = int(math.log2(len(state_vector)))
+        transposed_vector = np.reshape(state_vector, [2] * N).transpose(*wire_order)
+        return transposed_vector.flatten()
+
     def _apply_qubit_state_vector(self, op):
         """Initialize state with a state vector"""
-        wires = op.wires
+        wires = self.map_wires(op.wires)
         input_state = op.parameters[0]
 
         if len(input_state) != 2 ** len(wires):
@@ -184,7 +203,7 @@ class QulacsDevice(QubitDevice):
         if not np.isclose(np.linalg.norm(input_state, 2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        input_state = _reverse_state(input_state)
+        input_state = self._transpose_state_for_wires(input_state, wires)
 
         # call qulacs' state initialization
         self._state.load(input_state)

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -64,6 +64,26 @@ def _reverse_state(state_vector):
     return reversed_state
 
 
+def _transpose_state_for_wires(state_vector, wires):
+    """Transpose state vector if the wires are in non-consecutive order
+
+    Note, this also reverses the state, same as `_reverse_state()`.
+
+    Args:
+        state_vector (iterable[complex]): vector containing the amplitudes
+        wires (Wires): wires that get initialized in the state
+
+    Returns:
+        array[complex]: transposed array
+
+    """
+    wire_order = np.array(wires).argsort().argsort()[::-1]
+
+    N = int(math.log2(len(state_vector)))
+    transposed_vector = np.reshape(state_vector, [2] * N).transpose(*wire_order)
+    return transposed_vector.flatten()
+
+
 # tolerance for numerical errors
 tolerance = 1e-10
 
@@ -172,25 +192,6 @@ class QulacsDevice(QubitDevice):
             else:
                 self._apply_gate(op)
 
-    def _transpose_state_for_wires(self, state_vector, wires):
-        """Transpose state vector if the wires are in non-consecutive order
-
-        Note, this also reverses the state, same as `_reverse_state()`.
-
-        Args:
-            state_vector (iterable[complex]): vector containing the amplitudes
-            wires (Wires): wires that get initialized in the state
-
-        Returns:
-            array[complex]: transposed array
-
-        """
-        wire_order = np.array(wires).argsort().argsort()[::-1]
-
-        N = int(math.log2(len(state_vector)))
-        transposed_vector = np.reshape(state_vector, [2] * N).transpose(*wire_order)
-        return transposed_vector.flatten()
-
     def _apply_qubit_state_vector(self, op):
         """Initialize state with a state vector"""
         wires = self.map_wires(op.wires)
@@ -203,7 +204,7 @@ class QulacsDevice(QubitDevice):
         if not np.isclose(np.linalg.norm(input_state, 2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        input_state = self._transpose_state_for_wires(input_state, wires)
+        input_state = _transpose_state_for_wires(input_state, wires)
 
         # call qulacs' state initialization
         self._state.load(input_state)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -256,7 +256,7 @@ class TestStateApply:
 
     def test_apply_errors_qubit_state_vector(self):
         """Test that apply fails for incorrect state preparation."""
-        dev = QulacsDevice(1)
+        dev = QulacsDevice(2)
 
         with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
             dev.apply([qml.QubitStateVector(np.array([1, -1]), wires=[0])])


### PR DESCRIPTION
Fixes the issue when passing wires to `QubitStateVector` with an unsorted order (e.g. `wires=[2, 1, 0]` vs `wires=[0, 1, 2]`).

```python
dev = qml.device('qulacs.simulator', wires=3)

par = np.array([0, 1, 0, 0, 0, 0, 0, 0])

@qml.qnode(dev)
def circuit():
    qml.QubitStateVector(par, wires=[2, 1, 0])
    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2))
```

Related issues: #24 