### PR TITLE
Fix issue when using a wire subset with `BasisState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 ### Bug fixes
 
-Fixes an issue when the wrong results are returned when passing non-consecutive wires to `QubitStateVector`.
-[(#25)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/25)
+* Fixed an issue when the wrong results are returned when passing non-consecutive wires to `QubitStateVector`.
+  [(#25)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/25)
+
+* Fixed issue when using a subset of wires with `BasisState`.
+  [(#26)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/26)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ### Bug fixes
 
-* Fixed an issue when the wrong results are returned when passing non-consecutive wires to `QubitStateVector`.
+* Fixed an issue where the wrong results are returned when passing non-consecutive wires to `QubitStateVector`.
   [(#25)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/25)
 
-* Fixed issue when using a subset of wires with `BasisState`.
+* Fixed issue where a state cannot be loaded into a Qulacs circuit when using a subset of wires with `BasisState`.
   [(#26)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/26)
 
 ### Breaking changes

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -216,15 +216,16 @@ class QulacsDevice(QubitDevice):
 
         n_basis_state = len(par[0])
 
-        # translate from PennyLane to Qulacs wire order
-        bits = np.zeros(self.num_wires, dtype=int)
-        bits[wires] = par[0]
-        bits = bits[::-1]
-
-        if not set(bits).issubset({0, 1}):
+        if not set(par[0]).issubset({0, 1}):
             raise ValueError("BasisState parameter must consist of 0 or 1 integers.")
         if n_basis_state != len(wires):
             raise ValueError("BasisState parameter and wires must be of equal length.")
+
+        # translate from PennyLane to Qulacs wire order
+        bits = np.zeros(self.num_wires, dtype=int)
+        print(bits, wires)
+        bits[wires] = par[0]
+        bits = bits[::-1]
 
         basis_state = 0
         for bit in bits:

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -223,7 +223,6 @@ class QulacsDevice(QubitDevice):
 
         # translate from PennyLane to Qulacs wire order
         bits = np.zeros(self.num_wires, dtype=int)
-        print(bits, wires)
         bits[wires] = par[0]
         bits = bits[::-1]
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -16,6 +16,7 @@ Base device class for PennyLane-Qulacs.
 """
 from functools import reduce
 import math, cmath
+import itertools as it
 
 import numpy as np
 from scipy.linalg import block_diag
@@ -62,26 +63,6 @@ def _reverse_state(state_vector):
     N = int(math.log2(len(state_vector)))
     reversed_state = state_vector.reshape([2] * N).T.flatten()
     return reversed_state
-
-
-def _transpose_state_for_wires(state_vector, wires):
-    """Transpose state vector if the wires are in non-consecutive order
-
-    Note, this also reverses the state, same as `_reverse_state()`.
-
-    Args:
-        state_vector (iterable[complex]): vector containing the amplitudes
-        wires (Wires): wires that get initialized in the state
-
-    Returns:
-        array[complex]: transposed array
-
-    """
-    wire_order = np.array(wires).argsort().argsort()[::-1]
-
-    N = int(math.log2(len(state_vector)))
-    transposed_vector = np.reshape(state_vector, [2] * N).transpose(*wire_order)
-    return transposed_vector.flatten()
 
 
 # tolerance for numerical errors
@@ -192,6 +173,23 @@ class QulacsDevice(QubitDevice):
             else:
                 self._apply_gate(op)
 
+    def _expand_state(self, state_vector, wires):
+        """Expands state vector to more wires"""
+        basis_states = np.array(list(it.product([0, 1], repeat=len(wires))))
+
+        # get basis states to alter on full set of qubits
+        unravelled_indices = np.zeros((2 ** len(wires), self.num_wires), dtype=int)
+        unravelled_indices[:, wires] = basis_states
+
+        # get indices for which the state is changed to input state vector elements
+        ravelled_indices = np.ravel_multi_index(unravelled_indices.T, [2] * self.num_wires)
+
+        state_vector = self._scatter(ravelled_indices, state_vector, [2 ** self.num_wires])
+        state_vector = self._reshape(state_vector, [2] * self.num_wires)
+        state_vector = self._asarray(state_vector, dtype=self.C_DTYPE)
+
+        return state_vector.flatten()
+
     def _apply_qubit_state_vector(self, op):
         """Initialize state with a state vector"""
         wires = self.map_wires(op.wires)
@@ -204,7 +202,9 @@ class QulacsDevice(QubitDevice):
         if not np.isclose(np.linalg.norm(input_state, 2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 
-        input_state = _transpose_state_for_wires(input_state, wires)
+        if len(wires) != self.num_wires or sorted(wires) != wires:
+            input_state = self._expand_state(input_state, wires)
+        input_state = _reverse_state(input_state)
 
         # call qulacs' state initialization
         self._state.load(input_state)
@@ -214,9 +214,12 @@ class QulacsDevice(QubitDevice):
         wires = op.wires
         par = op.parameters
 
+        n_basis_state = len(par[0])
+
         # translate from PennyLane to Qulacs wire order
-        bits = par[0][::-1]
-        n_basis_state = len(bits)
+        bits = np.zeros(self.num_wires, dtype=int)
+        bits[wires] = par[0]
+        bits = bits[::-1]
 
         if not set(bits).issubset({0, 1}):
             raise ValueError("BasisState parameter must consist of 0 or 1 integers.")

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -184,9 +184,9 @@ class QulacsDevice(QubitDevice):
         # get indices for which the state is changed to input state vector elements
         ravelled_indices = np.ravel_multi_index(unravelled_indices.T, [2] * self.num_wires)
 
-        state_vector = self._scatter(ravelled_indices, state_vector, [2 ** self.num_wires])
-        state_vector = self._reshape(state_vector, [2] * self.num_wires)
-        state_vector = self._asarray(state_vector, dtype=self.C_DTYPE)
+        state = np.zeros([2 ** self.num_wires], dtype=np.complex128)
+        state[ravelled_indices] = state_vector
+        state_vector = state.reshape([2] * self.num_wires)
 
         return state_vector.flatten()
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -340,3 +340,24 @@ class TestStateApply:
             "on a qulacs.simulator device.",
         ):
             dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
+
+
+@pytest.mark.parametrize(
+    "state, device_wires, op_wires, expected",
+    [
+        (np.array([1, 0]), 2, [0], [1, 0, 0, 0]),
+        (np.array([0, 1]), 2, [0], [0, 0, 1, 0]),
+        (np.array([1, 1]) / np.sqrt(2), 2, [1], np.array([1, 1, 0, 0]) / np.sqrt(2)),
+        (np.array([1, 1]) / np.sqrt(2), 3, [0], np.array([1, 0, 0, 0, 1, 0, 0, 0]) / np.sqrt(2)),
+        (np.array([1, 2, 3, 4]) / np.sqrt(48), 3, [0, 1], np.array([1, 0, 2, 0, 3, 0, 4, 0]) / np.sqrt(48)),
+        (np.array([1, 2, 3, 4]) / np.sqrt(48), 3, [1, 0], np.array([1, 0, 3, 0, 2, 0, 4, 0]) / np.sqrt(48)),
+        (np.array([1, 2, 3, 4]) / np.sqrt(48), 3, [0, 2], np.array([1, 2, 0, 0, 3, 4, 0, 0]) / np.sqrt(48)),
+        (np.array([1, 2, 3, 4]) / np.sqrt(48), 3, [1, 2], np.array([1, 2, 3, 4, 0, 0, 0, 0]) / np.sqrt(48)),
+    ],
+)
+def test_expand_state(state, op_wires, device_wires, expected, tol):
+    """Test that the expand_state method works as expected."""
+    dev = QulacsDevice(device_wires)
+    res = dev._expand_state(state, op_wires)
+
+    assert np.allclose(res, expected, tol)


### PR DESCRIPTION
Fixes an issue when calling `BasisState` when using a subset of the device wires.

The following now works:
```python
dev = qml.device("qulacs.simulator", wires=2)

@qml.qnode(dev)
def circuit():
    qml.BasisState([1], wires=1)
    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))

circuit()
```
Previously it output `[-1, 1]` and now it should output the correct `[1, -1]`.