### PR TITLE
Updated links in the docs folder to point to PennyLaneAI

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: doc/requirements.txt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.9
   install:
     - requirements: doc/requirements.txt
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -292,11 +292,11 @@ html_theme_options = {
     "table_header_border": "#19b37b",
     "download_button": "#19b37b",
     # gallery options
-    # "github_repo": "XanaduAI/PennyLane",
+    # "github_repo": "PennyLaneAI/PennyLane",
     # "gallery_dirs": "tutorials",
 }
 
-edit_on_github_project = 'XanaduAI/pennylane-qulacs'
+edit_on_github_project = 'PennyLaneAI/pennylane-qulacs'
 edit_on_github_branch = 'master/doc'
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/doc/xanadu_theme/footer.html
+++ b/doc/xanadu_theme/footer.html
@@ -14,7 +14,7 @@
           <hr width=100px class="d-inline-block mt-0 mb-1 Deep-purple accent-4">
           <ul class="list-unstyled">
             <li><a class="" href="https://pennylane.ai/">Home page</a></li>
-            <li><a class="" href="https://github.com/XanaduAI/pennylane">GitHub</a></li>
+            <li><a class="" href="https://github.com/PennyLaneAI/pennylane">GitHub</a></li>
             <li><a class="" href="https://pennylane.readthedocs.io/">Documentation</a></li>
             <li><a class="" href="https://discuss.pennylane.ai/">Discussion forum</a></li>
             <li><a class="" href="https://twitter.com/pennylaneai/">Twitter</a></li>
@@ -38,9 +38,9 @@
           <ul class="list-unstyled">
             <li><a class="" href="https://www.xanadu.ai/">Home</a></li>
             <li><a class="" href="https://www.xanadu.ai/hardware/">Hardware</a></li>
-            <li><a class="" href="https://www.xanadu.ai/software/">Software</a></li>
+            <li><a class="" href="https://www.xanadu.ai/pennylane">PennyLane</a></li>
             <li><a class="" href="https://www.xanadu.ai/research">Research</a></li>
-            <li><a class="" href="https://medium.com/XanaduAI">Blog</a></li>
+            <li><a class="" href="https://pennylane.ai/blog">Blog</a></li>
             <li><a class="" href="https://www.xanadu.ai/about/">About</a></li>
           </ul>
         </div>

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -56,7 +56,7 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/pennyLane-qulacs">
+        <a class="nav-link" href="https://github.com/PennyLaneAI/pennyLane-qulacs">
           <i class="fab fa-github"></i> GitHub
         </a>
       </li>

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -285,7 +285,7 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
         tutorialUrlArray[0] = "examples"
 
-    var githubLink = "https://github.com/XanaduAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
+    var githubLink = "https://github.com/PennyLaneAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
         pythonLink = $(".reference.download")[0].href,
         notebookLink = $(".reference.download")[1].href,
         notebookDownloadPath = notebookLink.split('_downloads')[1].split('/').pop();

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/PennyLaneAI/pennylane.git@master
+pennylane>=0.15
 Qulacs>=0.1.10.1
 numpy~=1.16


### PR DESCRIPTION
Some links of PennyLane and the PennyLane plugin were still pointing to the XanaduAI organization instead of PennyLaneAI. These are now updated and the link for the blog points to the PennyLane blog.