### PR TITLE
Update to support `Operator.eigvals` as a method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Bug fixes
 
+* Updates the plugin to be compatible with the use of `Operator.eigvals` as a method.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 * Updates the plugin to be compatible with the use of `Operator.eigvals` as a method.
+  [(#35)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/35)
 
 ### Contributors
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -74,7 +74,7 @@ class QulacsDevice(QubitDevice):
 
     name = "Qulacs device"
     short_name = "qulacs.simulator"
-    pennylane_requires = ">=0.24.0"
+    pennylane_requires = ">=0.11.0"
     version = __version__
     author = "Steven Oud and Xanadu"
     gpu_supported = GPU_SUPPORTED
@@ -347,7 +347,10 @@ class QulacsDevice(QubitDevice):
                 return qulacs_observable.get_expectation_value(self._pre_rotated_state)
 
             # exact expectation value
-            eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
+            if callable(observable.eigvals):
+                eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
+            else:  # older version of pennylane
+                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
             prob = self.probability(wires=observable.wires)
             return self._dot(eigvals, prob)
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -74,7 +74,7 @@ class QulacsDevice(QubitDevice):
 
     name = "Qulacs device"
     short_name = "qulacs.simulator"
-    pennylane_requires = ">=0.11.0"
+    pennylane_requires = ">=0.24.0"
     version = __version__
     author = "Steven Oud and Xanadu"
     gpu_supported = GPU_SUPPORTED
@@ -347,10 +347,7 @@ class QulacsDevice(QubitDevice):
                 return qulacs_observable.get_expectation_value(self._pre_rotated_state)
 
             # exact expectation value
-            if callable(observable.eigvals):
-                eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
-            else: # older version of pennylane
-                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
+            eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
             prob = self.probability(wires=observable.wires)
             return self._dot(eigvals, prob)
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -347,7 +347,10 @@ class QulacsDevice(QubitDevice):
                 return qulacs_observable.get_expectation_value(self._pre_rotated_state)
 
             # exact expectation value
-            eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
+            if callable(observable.eigvals):
+                eigvals = self._asarray(observable.eigvals(), dtype=self.R_DTYPE)
+            else: # older version of pennylane
+                eigvals = self._asarray(observable.eigvals, dtype=self.R_DTYPE)
             prob = self.probability(wires=observable.wires)
             return self._dot(eigvals, prob)
 


### PR DESCRIPTION
Due to [PennyLane PR #2498](https://github.com/PennyLaneAI/pennylane/pull/2498), `eigvals` is now a method rather than a property.