### PR TITLE
Set `returns_state=True` in capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-# Release 0.17.0-dev
+# Release 0.24.0-dev
 
 ### New features since last release
 
 ### Breaking changes
 
 ### Improvements
+
+* Defines the `returns_state` entry of the `capabilities` dictionary of the
+  device.
+  [(#36)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/36)
 
 ### Documentation
 
@@ -17,7 +21,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Christina Lee
+Christina Lee, Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 ### Improvements
 
-* Defines the `returns_state` entry of the `capabilities` dictionary of the
-  device.
-  [(#36)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/36)
-
 ### Documentation
 
 ### Bug fixes
+
+* Defines the missing `returns_state` entry of the `capabilities` dictionary of
+  the device.
+  [(#36)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/36)
 
 * Updates the plugin to be compatible with the use of `Operator.eigvals` as a method.
   [(#35)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/35)

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -79,7 +79,12 @@ class QulacsDevice(QubitDevice):
     author = "Steven Oud and Xanadu"
     gpu_supported = GPU_SUPPORTED
 
-    _capabilities = {"model": "qubit", "tensor_observables": True, "inverse_operations": True, "returns_state": True}
+    _capabilities = {
+        "model": "qubit",
+        "tensor_observables": True,
+        "inverse_operations": True,
+        "returns_state": True,
+    }
 
     _operation_map = {
         "QubitStateVector": None,

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -79,7 +79,7 @@ class QulacsDevice(QubitDevice):
     author = "Steven Oud and Xanadu"
     gpu_supported = GPU_SUPPORTED
 
-    _capabilities = {"model": "qubit", "tensor_observables": True, "inverse_operations": True}
+    _capabilities = {"model": "qubit", "tensor_observables": True, "inverse_operations": True, "returns_state": True}
 
     _operation_map = {
         "QubitStateVector": None,

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -36,6 +36,7 @@ class TestDeviceUnits:
         assert dev._capabilities["model"] == "qubit"
         assert dev._capabilities["tensor_observables"]
         assert dev._capabilities["inverse_operations"]
+        assert dev._capabilities["returns_state"]
         assert isinstance(dev._state, QuantumState)
         assert isinstance(dev._circuit, QuantumCircuit)
 


### PR DESCRIPTION
The QulacsDevice class is capable of returning the state, yet it doesn't define a `returns_state=True` entry in the `capabilities` dictionary of the device (see [the explanation of `capabilities` here](https://pennylane.readthedocs.io/en/stable/development/plugins.html#device-capabilities)).