### PR TITLE
Remove inplace inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+Albert Mitjans Coma
+
 ---
 
 # Release 0.28.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* Removed support for in-place inversion of operations (e.g. `qml.PauliX(0).inv()`). Users should
+  use `qml.adjoint` instead.
+  [(#46)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/46)
+
 ### Documentation
 
 ### Bug fixes
@@ -15,6 +19,7 @@
 This release contains contributions from (in alphabetical order):
 
 ---
+
 # Release 0.28.0
 
 ### Breaking changes
@@ -29,6 +34,7 @@ This release contains contributions from (in alphabetical order):
 Christina Lee
 
 ---
+
 # Release 0.24.0
 
 ### Improvements

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -202,10 +202,6 @@ class QulacsDevice(QubitDevice):
         wires = self.map_wires(op.wires)
         input_state = op.parameters[0]
 
-        if len(input_state) != 2 ** len(wires):
-            raise ValueError("State vector must be of length 2**wires.")
-        if input_state.ndim != 1 or len(input_state) != 2 ** len(wires):
-            raise ValueError("State vector must be of length 2**wires.")
         if not np.isclose(np.linalg.norm(input_state, 2), 1.0, atol=tolerance):
             raise ValueError("Sum of amplitudes-squared does not equal one.")
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -19,11 +19,9 @@ import math, cmath
 import itertools as it
 
 import numpy as np
-from scipy.linalg import block_diag
 
 from pennylane import QubitDevice, DeviceError
-from pennylane.ops import QubitStateVector, BasisState, QubitUnitary, CRZ, PhaseShift
-from pennylane.wires import Wires
+from pennylane.ops import QubitStateVector, BasisState, QubitUnitary, CRZ, PhaseShift, Adjoint
 
 import qulacs.gate as gate
 from qulacs import QuantumCircuit, QuantumState, Observable
@@ -166,17 +164,21 @@ class QulacsDevice(QubitDevice):
                     "Operation {} cannot be used after other Operations have already been applied "
                     "on a {} device.".format(op.name, self.short_name)
                 )
+            inverse = False
+            if isinstance(op, Adjoint):
+                inverse = True
+                op = op.base
 
             if isinstance(op, QubitStateVector):
                 self._apply_qubit_state_vector(op)
             elif isinstance(op, BasisState):
                 self._apply_basis_state(op)
             elif isinstance(op, QubitUnitary):
-                self._apply_qubit_unitary(op)
+                self._apply_qubit_unitary(op, inverse)
             elif isinstance(op, (CRZ, PhaseShift)):
-                self._apply_matrix(op)
+                self._apply_matrix(op, inverse)
             else:
-                self._apply_gate(op)
+                self._apply_gate(op, inverse)
 
     def _expand_state(self, state_vector, wires):
         """Expands state vector to more wires"""
@@ -238,7 +240,7 @@ class QulacsDevice(QubitDevice):
         # call qulacs' basis state initialization
         self._state.set_computational_basis(basis_state)
 
-    def _apply_qubit_unitary(self, op):
+    def _apply_qubit_unitary(self, op, inverse=False):
         """Apply unitary to state"""
         # translate op wire labels to consecutive wire labels used by the device
         device_wires = self.map_wires(op.wires)
@@ -247,7 +249,7 @@ class QulacsDevice(QubitDevice):
         if len(par[0]) != 2 ** len(device_wires):
             raise ValueError("Unitary matrix must be of shape (2**wires, 2**wires).")
 
-        if op.inverse:
+        if inverse:
             par[0] = par[0].conj().T
 
         # reverse wires (could also change par[0])
@@ -256,14 +258,14 @@ class QulacsDevice(QubitDevice):
         self._circuit.add_gate(unitary_gate)
         unitary_gate.update_quantum_state(self._state)
 
-    def _apply_matrix(self, op):
+    def _apply_matrix(self, op, inverse=False):
         """Apply predefined gate-matrix to state (must follow qulacs convention)"""
         # translate op wire labels to consecutive wire labels used by the device
         device_wires = self.map_wires(op.wires)
         par = op.parameters
 
         mapped_operation = self._operation_map[op.name]
-        if op.inverse:
+        if inverse:
             mapped_operation = self._get_inverse_operation(mapped_operation, device_wires, par)
 
         if callable(mapped_operation):
@@ -276,7 +278,7 @@ class QulacsDevice(QubitDevice):
         self._circuit.add_gate(dense_gate)
         gate.DenseMatrix(device_wires.labels, gate_matrix).update_quantum_state(self._state)
 
-    def _apply_gate(self, op):
+    def _apply_gate(self, op, inverse=False):
         """Apply native qulacs gate"""
 
         # translate op wire labels to consecutive wire labels used by the device
@@ -284,7 +286,7 @@ class QulacsDevice(QubitDevice):
         par = op.parameters
 
         mapped_operation = self._operation_map[op.name]
-        if op.inverse:
+        if inverse:
             mapped_operation = self._get_inverse_operation(mapped_operation, device_wires, par)
 
         # Negating the parameters such that it adheres to qulacs

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -192,16 +192,6 @@ class TestStateApply:
 
         assert np.allclose(res, expected, tol)
 
-    def test_invalid_qubit_state_vector(self):
-        """Test that an exception is raised if the state
-        vector is the wrong size"""
-        dev = QulacsDevice(2)
-        state = np.array([0, 123.432])
-
-        with pytest.raises(ValueError, match="State vector must have shape"):
-            op = qml.QubitStateVector(state, wires=[0, 1])
-            dev.apply([op])
-
     @pytest.mark.parametrize("op,mat", single_qubit)
     def test_single_qubit_no_parameters(self, init_state, op, mat, tol):
         """Test PauliX application"""
@@ -294,28 +284,6 @@ class TestStateApply:
         res = dev.state
         expected = func(theta) @ state
         assert np.allclose(res, expected, tol)
-
-    def test_apply_errors_qubit_state_vector(self):
-        """Test that apply fails for incorrect state preparation."""
-        dev = QulacsDevice(2)
-
-        with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
-            dev.apply([qml.QubitStateVector(np.array([1, -1]), wires=[0])])
-
-        with pytest.raises(ValueError, match="State vector must have shape"):
-            p = np.array([1, 0, 1, 1, 0]) / np.sqrt(3)
-            dev.reset()
-            dev.apply([qml.QubitStateVector(p, wires=[0, 1])])
-
-        with pytest.raises(
-            qml.DeviceError,
-            match="Operation QubitStateVector cannot be used after other Operations have already been applied "
-            "on a qulacs.simulator device.",
-        ):
-            dev.reset()
-            dev.apply(
-                [qml.RZ(0.5, wires=[0]), qml.QubitStateVector(np.array([0, 1, 0, 0]), wires=[0, 1])]
-            )
 
     def test_apply_errors_basis_state(self):
         """Test that apply fails for incorrect basis state preparation."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,7 @@ class TestIntegration:
 
         @qml.qnode(dev)
         def circuit():
-            qml.RY(theta, wires=[0]).inv()
+            qml.adjoint(qml.RY(theta, wires=[0]))
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliX(wires=0)), qml.expval(qml.PauliX(wires=1))

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -17,15 +17,13 @@ import pytest
 import numpy as np
 import pennylane as qml
 from pennylane_qulacs.qulacs_device import QulacsDevice
-from qulacs import QuantumState, QuantumCircuit, Observable
+from qulacs import QuantumState, QuantumCircuit
 
 
 class TestDeviceUnits:
     """Unit tests for the plugin."""
 
-    @pytest.mark.parametrize(
-        "num_wires, shots", [(1, None), (2, 184), (3, 1)]
-    )
+    @pytest.mark.parametrize("num_wires, shots", [(1, None), (2, 184), (3, 1)])
     def test_device_attributes(self, num_wires, shots):
         """Test that attributes are set as expected."""
         dev = QulacsDevice(wires=num_wires, shots=shots)
@@ -35,7 +33,6 @@ class TestDeviceUnits:
         assert dev._samples is None
         assert dev._capabilities["model"] == "qubit"
         assert dev._capabilities["tensor_observables"]
-        assert dev._capabilities["inverse_operations"]
         assert dev._capabilities["returns_state"]
         assert isinstance(dev._state, QuantumState)
         assert isinstance(dev._circuit, QuantumCircuit)
@@ -78,18 +75,28 @@ class TestDeviceUnits:
         assert np.allclose(dev._state.get_vector(), expected)
         assert QuantumCircuit(4).calculate_depth() == 0
 
-    @pytest.mark.parametrize("obs,args,wires,supported", [
-        (qml.PauliX, [], [0], True),
-        (qml.Hadamard, [], [0], False),
-        (qml.Hermitian, [
-            np.array([
-                [1.02789352, 1.61296440 - 0.3498192j],
-                [1.61296440 + 0.3498192j, 1.23920938 + 0j]
-            ])
-        ], [0], False),
-        (lambda wires: qml.PauliX(wires[0]) @ qml.Hadamard(wires[1]), [], [0, 1], False),
-        (lambda wires: qml.PauliZ(wires[0]) @ qml.PauliY(wires[1]), [], [0, 1], True)
-        ])
+    @pytest.mark.parametrize(
+        "obs,args,wires,supported",
+        [
+            (qml.PauliX, [], [0], True),
+            (qml.Hadamard, [], [0], False),
+            (
+                qml.Hermitian,
+                [
+                    np.array(
+                        [
+                            [1.02789352, 1.61296440 - 0.3498192j],
+                            [1.61296440 + 0.3498192j, 1.23920938 + 0j],
+                        ]
+                    )
+                ],
+                [0],
+                False,
+            ),
+            (lambda wires: qml.PauliX(wires[0]) @ qml.Hadamard(wires[1]), [], [0, 1], False),
+            (lambda wires: qml.PauliZ(wires[0]) @ qml.PauliY(wires[1]), [], [0, 1], True),
+        ],
+    )
     def test_expval_hadamard(self, obs, args, wires, supported, mocker):
         """Test that QulacsDevice.expval() uses native calculations when possible"""
         dev = QulacsDevice(4)


### PR DESCRIPTION
- Use `qml.adjoint` instead of `.inv()`
- Remove checks for `QubitStateVector` (they were recently added inside its `__init__` method).