### PR TITLE
use correct pypi upload action version

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pytest tests --tb=native
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI }}


### PR DESCRIPTION
As instructions say [here](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-) (a warning came up when uploading various things for 0.31)