### PR TITLE
Fix image links in docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,7 +41,7 @@ Check out these demos to see the PennyLane-Qulacs plugin in action:
 
 .. title-card::
     :name: Intro to QAOA
-    :description: <img src="https://pennylane.ai/_images/qaoa_layer.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/qaoa_module/qaoa_layer.png" width="100%" />
     :link:  https://pennylane.ai/qml/demos/tutorial_qaoa_intro.html
 
 


### PR DESCRIPTION
The "Intro to QAOA" image link was broken in the docs:
<img width="784" alt="image" src="https://github.com/PennyLaneAI/pennylane-qulacs/assets/12532113/2c53cd59-0a66-4968-bb55-1c3b94e13c81">

This PR fixes the link to point to the right place in the QML repo