### PR TITLE
Fix deprecated import path for `QubitDevice`

### DIFF
--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -20,7 +20,8 @@ import itertools as it
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError
+from pennylane.devices import QubitDevice
+from pennylane import DeviceError
 from pennylane.ops import (
     QubitStateVector,
     BasisState,


### PR DESCRIPTION
pennylane.QubitDevice is deprecated in v0.39, importing QubitDevice from pennylane.devices instead.