### PR TITLE
Delete references to the removed `QubitStateVector` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking changes 💔
 
+* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+
 ### Deprecations 👋
 
 ### Documentation 📝
@@ -13,6 +15,8 @@
 ### Bug fixes 🐛
 
 ### Contributors ✍️
+
+Andrija Paurevic
 
 This release contains contributions from (in alphabetical order):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking changes 💔
 
 * The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+  [(#83)](https://github.com/PennyLaneAI/pennylane-qulacs/pull/83)
 
 ### Deprecations 👋
 

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -23,7 +23,6 @@ import numpy as np
 from pennylane.devices import QubitDevice
 from pennylane import DeviceError
 from pennylane.ops import (
-    StatePrep,
     BasisState,
     QubitUnitary,
     CRZ,

--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -23,7 +23,7 @@ import numpy as np
 from pennylane.devices import QubitDevice
 from pennylane import DeviceError
 from pennylane.ops import (
-    QubitStateVector,
+    StatePrep,
     BasisState,
     QubitUnitary,
     CRZ,
@@ -95,7 +95,6 @@ class QulacsDevice(QubitDevice):
 
     _operation_map = {
         "StatePrep": None,
-        "QubitStateVector": None,
         "BasisState": None,
         "QubitUnitary": None,
         "Toffoli": gate.TOFFOLI,
@@ -170,7 +169,7 @@ class QulacsDevice(QubitDevice):
         """
 
         for i, op in enumerate(operations):
-            if i > 0 and isinstance(op, (QubitStateVector, BasisState, StatePrep)):
+            if i > 0 and isinstance(op, (BasisState, StatePrep)):
                 raise DeviceError(
                     "Operation {} cannot be used after other Operations have already been applied "
                     "on a {} device.".format(op.name, self.short_name)
@@ -180,7 +179,7 @@ class QulacsDevice(QubitDevice):
                 inverse = True
                 op = op.base
 
-            if isinstance(op, (QubitStateVector, StatePrep)):
+            if isinstance(op, StatePrep):
                 self._apply_qubit_state_vector(op)
             elif isinstance(op, BasisState):
                 self._apply_basis_state(op)


### PR DESCRIPTION
**Context:**

Completing the deprecation cycle of `QubitStateVector` (see https://github.com/PennyLaneAI/pennylane/pull/6525)

**Description of the Change:**

Removed all references to the deprecated source code.

[sc-77482]