### PR TITLE
updating `setuptools`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip 
+          python -m pip install --upgrade pip setuptools>=75.8.1
 
           pip install -r requirements.txt
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements.txt
           pip install pytest-benchmark
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Build and install Plugin
         run: |
-          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1
           python setup.py bdist_wheel
           pattern="dist/pennylane*.whl"
           wheel=( $pattern )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@
 
 ### Bug fixes 🐛
 
+### Internal changes
+
+* Pinning `setuptools` in the CI to update how the plugin is installed.
+  [(#87)](https://github.com/PennyLaneAI/pennylane-cirq/pull/87)
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Pietropaolo Frisoni
 
 ---
 # Release 0.40.0

--- a/pennylane_qulacs/_version.py
+++ b/pennylane_qulacs/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.41.0-dev"


### PR DESCRIPTION
**Context:**
`setuptools` has had a release recently that normalizes package names:

References:
- pypa/setuptools#4766
- https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization

**Description of the Change:**
Due setuptools 75.8.0 and 75.8.1 outputting completely different package names, we cannot support both, so CI now "pins" to >=75.8.1.

**Benefits:**
Fix CI failures.

[sc-85704]