### PR TITLE
use new `pennylane.exceptions` module rather than top-level import

### DIFF
--- a/pennylane_qulacs/qulacs_device.py
+++ b/pennylane_qulacs/qulacs_device.py
@@ -21,7 +21,7 @@ import itertools as it
 import numpy as np
 
 from pennylane.devices import QubitDevice
-from pennylane import DeviceError
+from pennylane.exceptions import DeviceError
 from pennylane.ops import (
     BasisState,
     QubitUnitary,

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -301,7 +301,7 @@ class TestStateApply:
 
         dev.reset()
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="Operation BasisState cannot be used after other Operations have already been applied "
             "on a qulacs.simulator device.",
         ):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -43,7 +43,7 @@ class TestDeviceUnits:
         monkeypatch.setattr(QulacsDevice, "gpu_supported", False)
 
         with pytest.raises(
-            qml.DeviceError, match="GPU not supported with installed version of qulacs"
+            qml.exceptions.DeviceError, match="GPU not supported with installed version of qulacs"
         ):
             QulacsDevice(3, gpu=True)
 


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7205 adds the new `exceptions` module.

**Description of the Change:**

Update to use that new module rather than top level imports.

**Benefits:** Should not depend on top-level imports.

**Possible Drawbacks:** None

[sc-88954]